### PR TITLE
Adds filetree to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ all of that code results in this window:
 
 ![helloworld](./assets/images/helloworld.png)
 
+The file structure for this example can be seen below:
+
+<img alt="banana-example-filetree" src="https://github.com/user-attachments/assets/0743a4d3-1c41-49eb-9c23-dd6609be3bb2" width="325" /><br />
+
 this may seem underwhelming as the above result can be done in a few lines of lua, but banana starts becoming extremely helpful when you start doing more complex rendering cases like nested tags, css grid display, or css flex display. For a better example, check out [banana-example](https://github.com/CWood-sdf/banana-example) or the other examples below
 
 ### Other examples


### PR DESCRIPTION
## Issue

I was a bit confused by what should go where when reading the [example](https://github.com/CWood-sdf/banana.nvim?tab=readme-ov-file#example) on the README at first -- after looking at the banana-example repo I saw the file structure and came to an understanding. 

## Proposed Fix

We may be able to get more people trying the plugin out if there are less places they have to navigate to in order to get a clear understanding of the plugin and its capabilities.

With this, it may help others understand the example more clearly if we show the filetree with the example. It's a small thing -- but it may help, and the real-estate it takes on the README is minimal (but not zero).