### PR TITLE
Adds Recipe.md and tweaks `nml` section of Tags.md

### DIFF
--- a/wiki/Recipes.md
+++ b/wiki/Recipes.md
@@ -1,0 +1,40 @@
+Here are some useful snippets/solutions for various problems.
+
+## Creating a Command
+
+```lua
+local M = {}
+
+M.instance = nil
+
+function M.setup()
+  -- Call `:YourCommand` in neovim to create the instance
+  vim.api.nvim_create_user_command("YourCommand", function()
+    if M.instance == nil then
+      M.instance = require("banana.instance").newInstance("stuff", "arbitrary-buffer-name")
+    end
+    M.instance:open()
+  end, {})
+end
+```
+
+where `stuff` is associated to the file: `your-plugin-name/banana/stuff/index.nml`
+
+## Load nml into element on command "init"
+
+```lua
+function M.__banana_run(document)
+  local container = document:getElementById("container")
+  if #container:children() == 0 then
+    document:loadNmlTo("stuff/coolPage", container)
+  end
+end
+```
+
+where `container` is a `div` [tag](https://github.com/CWood-sdf/banana.nvim/wiki/Tags#div) in loaded nml.
+
+```html
+<div id="container"></div>
+```
+
+and `coolPage` is associated to the file: `your-plugin-name/banana/stuff/coolPage.nml`.

--- a/wiki/Tags.md
+++ b/wiki/Tags.md
@@ -78,7 +78,10 @@ currently, the only supported identifiers are `buf-name` and `win-name` (for `vi
 
 the nml tag for a document
 
-all nml files that are directly opened by an instance (eg passed as the file parameter to create an instance) must have an nml tag as root tag
+Notes/Rules:
+- all nml files that are directly opened by an instance (eg passed as the file parameter to create an instance) must have an nml tag as root tag
+- nml files cannot be styled with highlights (e.g. `hl-bg`)
+
 
 ## `ol`
 


### PR DESCRIPTION
## Issue

- https://github.com/CWood-sdf/banana.nvim/issues/11

> In my experience getting started meant trying to understand the example in the README, getting a little bit confused, checking out the example and becoming even more confused until I wasn't.

## Proposed Fix

Recipes.md + pitfall hint for nml tag in Tag.md. Recipes.md is for storing solutions to various problems people might want to solve. I see it as a great way for those wanting to learn the plugin being able to do so with isolated chunks of logic.